### PR TITLE
Some wording changes and a couple Dragoon updates

### DIFF
--- a/cards/src/main/resources/cards/custom/Exile/Core Set/weapon_captured_flag.json
+++ b/cards/src/main/resources/cards/custom/Exile/Core Set/weapon_captured_flag.json
@@ -6,7 +6,7 @@
   "damage": 5,
   "durability": 2,
   "rarity": "RARE",
-  "description": "Opener: Draw two minions from your deck.",
+  "description": "Opener: Draw 2 minions.",
   "battlecry": {
     "spell": {
       "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/Exile/Verdant Dreams/spell_reserve_corps.json
+++ b/cards/src/main/resources/cards/custom/Exile/Verdant Dreams/spell_reserve_corps.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "CAMO",
   "rarity": "COMMON",
-  "description": "Draw a Demon, Dragon, and Pirate from your deck.",
+  "description": "Draw a Demon, Dragon, and Pirate.",
   "targetSelection": "NONE",
   "spell": {
     "class": "MetaSpell",

--- a/cards/src/main/resources/cards/custom/Oni-Queen/Verdant Dreams Set/spell_gather_in_the_shadows.json
+++ b/cards/src/main/resources/cards/custom/Oni-Queen/Verdant Dreams Set/spell_gather_in_the_shadows.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "BLUEGREY",
   "rarity": "EPIC",
-  "description": "Draw a Hidden minion from your deck. If your hand has duplicates, draw 3 instead.",
+  "description": "Draw a Hidden minion. If your hand has duplicates, draw 3 instead.",
   "targetSelection": "NONE",
   "spell": {
     "class": "EitherOrSpell",

--- a/cards/src/main/resources/cards/custom/arch/basic/spell_sword_in_stone.json
+++ b/cards/src/main/resources/cards/custom/arch/basic/spell_sword_in_stone.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "LIGHTBROWN",
   "rarity": "FREE",
-  "description": "Draw a weapon from your deck.",
+  "description": "Draw a weapon.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/arch/verdant/minion_cobble_elemental.json
+++ b/cards/src/main/resources/cards/custom/arch/verdant/minion_cobble_elemental.json
@@ -7,7 +7,7 @@
   "baseHp": 8,
   "rarity": "RARE",
   "race": "ELEMENTAL",
-  "description": "Guard. Aftermath: Draw two Elementals.",
+  "description": "Guard. Aftermath: Draw 2 Elementals.",
   "deathrattle": {
     "class": "FromDeckToHandSpell",
     "value": 2,

--- a/cards/src/main/resources/cards/custom/arch/verdant/minion_cobble_elemental.json
+++ b/cards/src/main/resources/cards/custom/arch/verdant/minion_cobble_elemental.json
@@ -7,7 +7,7 @@
   "baseHp": 8,
   "rarity": "RARE",
   "race": "ELEMENTAL",
-  "description": "Guard. Aftermath: Draw two Elementals from your deck.",
+  "description": "Guard. Aftermath: Draw two Elementals.",
   "deathrattle": {
     "class": "FromDeckToHandSpell",
     "value": 2,

--- a/cards/src/main/resources/cards/custom/arch/verdant/spell_dream_of_armaments.json
+++ b/cards/src/main/resources/cards/custom/arch/verdant/spell_dream_of_armaments.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "LIGHTBROWN",
   "rarity": "EPIC",
-  "description": "Draw 10 weapons from your deck.",
+  "description": "Draw 10 weapons.",
   "spell": {
     "class": "FromDeckToHandSpell",
     "value": 10,

--- a/cards/src/main/resources/cards/custom/group0/doombubbles/neutral/minion_dragonling_pet.json
+++ b/cards/src/main/resources/cards/custom/group0/doombubbles/neutral/minion_dragonling_pet.json
@@ -7,7 +7,7 @@
   "baseHp": 2,
   "rarity": "LEGENDARY",
   "race": "DRAGON",
-  "description": "Start of Game: If your deck only contains Dragons, draw this card from your deck.",
+  "description": "Start of Game: If your deck only contains Dragons, draw this.",
   "deckTrigger": {
     "eventTrigger": {
       "class": "GameStartTrigger",

--- a/cards/src/main/resources/cards/custom/group0/misc/minion_treasure_hunter.json
+++ b/cards/src/main/resources/cards/custom/group0/misc/minion_treasure_hunter.json
@@ -7,7 +7,7 @@
   "baseHp": 4,
   "rarity": "COMMON",
   "race": "PIRATE",
-  "description": "Opener: Draw a 0-Cost card from your deck.",
+  "description": "Opener: Draw a 0-Cost card.",
   "battlecry": {
     "spell": {
       "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_chronocaller.json
+++ b/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_chronocaller.json
@@ -7,7 +7,7 @@
   "baseHp": 6,
   "rarity": "RARE",
   "race": "NONE",
-  "description": "Opener: Summon two minions from your deck that costs (2).",
+  "description": "Opener: Summon two 2-Cost minions from your deck.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_dimensional_courier.json
+++ b/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_dimensional_courier.json
@@ -6,7 +6,7 @@
   "baseAttack": 1,
   "baseHp": 2,
   "rarity": "EPIC",
-  "description": "Opener: Choose a minion. Draw a card from your deck with the same cost as it.",
+  "description": "Opener: Choose a minion. Draw a card with the same Cost as it.",
   "battlecry": {
     "targetSelection": "MINIONS",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_dimensional_courier.json
+++ b/cards/src/main/resources/cards/custom/group0/the_sands_of_time/neutral/minion_dimensional_courier.json
@@ -6,7 +6,7 @@
   "baseAttack": 1,
   "baseHp": 2,
   "rarity": "EPIC",
-  "description": "Opener: Choose a minion. Draw a card with the same Cost as it.",
+  "description": "Opener: Choose a minion. Draw a card with the same Cost.",
   "battlecry": {
     "targetSelection": "MINIONS",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group0/year_of_the_gryphon/zandalari/minion_ghuun.json
+++ b/cards/src/main/resources/cards/custom/group0/year_of_the_gryphon/zandalari/minion_ghuun.json
@@ -7,7 +7,7 @@
   "baseHp": 6,
   "rarity": "LEGENDARY",
   "race": "DEMON",
-  "description": "Lifesteal. Damaged minions have +8/+8 and can't attack champions.",
+  "description": "Lifedrain. Damaged minions have +8/+8 and can't attack champions.",
   "attributes": {
     "LIFESTEAL": true
   },

--- a/cards/src/main/resources/cards/custom/group1/minion_harbinger_of_hope.json
+++ b/cards/src/main/resources/cards/custom/group1/minion_harbinger_of_hope.json
@@ -6,7 +6,7 @@
   "baseAttack": 3,
   "baseHp": 2,
   "rarity": "EPIC",
-  "description": "Aftermath: Draw a Legendary minion from your deck.",
+  "description": "Aftermath: Draw a Legendary minion.",
   "deathrattle": {
     "class": "FromDeckToHandSpell",
     "value": 1,

--- a/cards/src/main/resources/cards/custom/group10/spellsource_core_common/minion_shedding_chameleon.json
+++ b/cards/src/main/resources/cards/custom/group10/spellsource_core_common/minion_shedding_chameleon.json
@@ -7,7 +7,7 @@
   "baseHp": 2,
   "rarity": "COMMON",
   "race": "BEAST",
-  "description": "Aftermath: Draw a minion from your deck.",
+  "description": "Aftermath: Draw a minion.",
   "deathrattle": {
     "class": "FromDeckToHandSpell",
     "value": 1,

--- a/cards/src/main/resources/cards/custom/group10/spellsource_core_common/minion_yokai_bonder.json
+++ b/cards/src/main/resources/cards/custom/group10/spellsource_core_common/minion_yokai_bonder.json
@@ -6,7 +6,7 @@
   "baseAttack": 7,
   "baseHp": 5,
   "rarity": "COMMON",
-  "description": "Dash. Whenever this attacks, draw a Beast from your deck.",
+  "description": "Dash. Whenever this attacks, draw a Beast.",
   "trigger": {
     "eventTrigger": {
       "class": "TargetAcquisitionTrigger",

--- a/cards/src/main/resources/cards/custom/group2/baron/minion_mystiva.json
+++ b/cards/src/main/resources/cards/custom/group2/baron/minion_mystiva.json
@@ -6,7 +6,7 @@
   "baseAttack": 1,
   "baseHp": 3,
   "rarity": "LEGENDARY",
-  "description": "Whenever you cast a spell, draw all copies of it from your deck.",
+  "description": "Whenever you cast a spell, draw all your other copies of it.",
   "trigger": {
     "eventTrigger": {
       "class": "SpellCastedTrigger",

--- a/cards/src/main/resources/cards/custom/group2/baron/minion_sparklefuser.json
+++ b/cards/src/main/resources/cards/custom/group2/baron/minion_sparklefuser.json
@@ -6,7 +6,7 @@
   "baseAttack": 4,
   "baseHp": 7,
   "rarity": "EPIC",
-  "description": "Adjacent minions have Lifesteal and Toxic.",
+  "description": "Adjacent minions have Lifedrain and Toxic.",
   "collectible": true,
   "set": "CUSTOM",
   "fileFormatVersion": 1,

--- a/cards/src/main/resources/cards/custom/group2/baron/spell_gather_strength.json
+++ b/cards/src/main/resources/cards/custom/group2/baron/spell_gather_strength.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "NAVY",
   "rarity": "FREE",
-  "description": "Draw a spell from your deck.",
+  "description": "Draw a spell.",
   "spell": {
     "class": "FromDeckToHandSpell",
     "value": 1,

--- a/cards/src/main/resources/cards/custom/group2/set_633/verdant/spell_lucid_landscape.json
+++ b/cards/src/main/resources/cards/custom/group2/set_633/verdant/spell_lucid_landscape.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "JADE",
   "rarity": "RARE",
-  "description": "Draw 2 spells from your deck. Restore #5 Health.",
+  "description": "Draw 2 spells. Restore #5 Health.",
   "targetSelection": "ANY",
   "spell": {
     "class": "MetaSpell",

--- a/cards/src/main/resources/cards/custom/group2/summoner/enchantment_souldrinking.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/enchantment_souldrinking.json
@@ -4,7 +4,7 @@
   "type": "ENCHANTMENT",
   "heroClass": "EGGPLANT",
   "rarity": "LEGENDARY",
-  "description": "The next card you play has Lifesteal.",
+  "description": "The next card you play has Lifedrain.",
   "trigger": {
     "eventTrigger": {
       "class": "CardPlayedTrigger",

--- a/cards/src/main/resources/cards/custom/group2/summoner/minion_purrfect_tracker.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/minion_purrfect_tracker.json
@@ -7,7 +7,7 @@
   "baseHp": 3,
   "rarity": "RARE",
   "race": "BEAST",
-  "description": "Opener: Draw two 0-Cost cards from your deck.",
+  "description": "Opener: Draw two 0-Cost cards.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group2/summoner/minion_skugg_the_unclean.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/minion_skugg_the_unclean.json
@@ -6,7 +6,7 @@
   "baseAttack": 4,
   "baseHp": 2,
   "rarity": "LEGENDARY",
-  "description": "Opener: For the rest of the game, summon a 2/2 Rat with Lifesteal whenever you Invoke.",
+  "description": "Opener: For the rest of the game, summon a 2/2 Rat with Lifedrain whenever you Invoke.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group2/summoner/minion_souldrinker_drake.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/minion_souldrinker_drake.json
@@ -7,7 +7,7 @@
   "baseHp": 4,
   "rarity": "RARE",
   "race": "DRAGON",
-  "description": "Lifesteal. Opener: Give the next card you play this turn Lifesteal.",
+  "description": "Lifesteal. Opener: Give the next card you play this turn Lifedrain.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group2/summoner/minion_squeak_freak.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/minion_squeak_freak.json
@@ -6,7 +6,7 @@
   "baseAttack": 1,
   "baseHp": 1,
   "rarity": "RARE",
-  "description": "Aftermath: Draw a 0-Cost card from your deck.",
+  "description": "Aftermath: Draw a 0-Cost card.",
   "deathrattle": {
     "class": "FromDeckToHandSpell",
     "cardFilter": {

--- a/cards/src/main/resources/cards/custom/group2/summoner/token_skugg_rat.json
+++ b/cards/src/main/resources/cards/custom/group2/summoner/token_skugg_rat.json
@@ -7,7 +7,7 @@
   "baseHp": 2,
   "rarity": "FREE",
   "race": "BEAST",
-  "description": "Lifesteal",
+  "description": "Lifedrain.",
   "attributes": {
     "LIFESTEAL": true
   },

--- a/cards/src/main/resources/cards/custom/group3/bug/classic/spell_forest_whispers.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/classic/spell_forest_whispers.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "AMBER",
   "rarity": "COMMON",
-  "description": "Draw a Beast from your deck.",
+  "description": "Draw a Beast.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group3/bug/classic/spell_pheromones.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/classic/spell_pheromones.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "AMBER",
   "rarity": "RARE",
-  "description": "Draw two 1-Cost cards from your deck.",
+  "description": "Draw two 1-Cost cards.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group3/bug/knights_of_the_frozen_throne/minion_vizier.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/knights_of_the_frozen_throne/minion_vizier.json
@@ -7,7 +7,7 @@
   "baseHp": 4,
   "rarity": "COMMON",
   "race": "BEAST",
-  "description": "Your Larva have Lifesteal.",
+  "description": "Your Larva have Lifedrain.",
   "aura": {
     "class": "AttributeAura",
     "target": "FRIENDLY_MINIONS",

--- a/cards/src/main/resources/cards/custom/group3/bug/knights_of_the_frozen_throne/spell_locust_swarm.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/knights_of_the_frozen_throne/spell_locust_swarm.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "AMBER",
   "rarity": "COMMON",
-  "description": "Lifesteal. Deal $3 damage to all enemy minions.",
+  "description": "Lifedrain. Deal $3 damage to all enemy minions.",
   "targetSelection": "NONE",
   "spell": {
     "class": "DamageSpell",

--- a/cards/src/main/resources/cards/custom/group3/bug/witchwood/minion_backwater_wise.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/witchwood/minion_backwater_wise.json
@@ -7,7 +7,7 @@
   "baseHp": 3,
   "rarity": "RARE",
   "race": "FAE",
-  "description": "Opener: If you control another Fae, draw a Fae from your deck.",
+  "description": "Opener: If you control another Fae, draw a Fae.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group3/bug/witchwood/spell_forest_calling.json
+++ b/cards/src/main/resources/cards/custom/group3/bug/witchwood/spell_forest_calling.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "AMBER",
   "rarity": "RARE",
-  "description": "Draw a Beast, Dragon, and Fae from your deck.",
+  "description": "Draw a Beast, Dragon, and Fae.",
   "targetSelection": "NONE",
   "spell": {
     "class": "MetaSpell",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/basic/minion_sweeper_drake.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/basic/minion_sweeper_drake.json
@@ -1,19 +1,18 @@
 {
-  "name": "Sweeper Drake",
-  "baseManaCost": 3,
+  "name": "Molten Whelp",
+  "baseManaCost": 2,
   "type": "MINION",
   "heroClass": "RUST",
   "baseAttack": 2,
   "baseHp": 2,
   "rarity": "FREE",
   "race": "DRAGON",
-  "description": "Opener: Summon two 1/1 Whelps.",
+  "description": "Opener: Deal 1 damage.",
   "battlecry": {
-    "targetSelection": "NONE",
+    "targetSelection": "ANY",
     "spell": {
-      "class": "SummonSpell",
-      "value": 2,
-      "card": "token_whelp"
+      "class": "DamageSpell",
+      "value": 1
     }
   },
   "attributes": {

--- a/cards/src/main/resources/cards/custom/group3/set_1087/basic/spell_the_little_swarm.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/basic/spell_the_little_swarm.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Little Swarm",
+  "name": "Sweeping Swarm",
   "baseManaCost": 4,
   "type": "SPELL",
   "heroClass": "RUST",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/blazing_brawls/minion_littlest_forerunner.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/blazing_brawls/minion_littlest_forerunner.json
@@ -1,0 +1,32 @@
+{
+  "name": "Littlest Forerunner",
+  "baseManaCost": 3,
+  "type": "MINION",
+  "heroClass": "RUST",
+  "baseAttack": 3,
+  "baseHp": 3,
+  "rarity": "RARE",
+  "description": "Supremacy: Your Dragons cost (1) less this turn.",
+  "trigger": {
+    "eventTrigger": {
+      "class": "SupremacyTrigger"
+    },
+    "spell": {
+      "class": "CardCostModifierSpell",
+      "target": "FRIENDLY_PLAYER",
+      "cardCostModifier": {
+        "class": "OneTurnCostModifier",
+        "value": 1,
+        "cardType": "MINION",
+        "operation": "SUBTRACT",
+		"race": "DRAGON"
+      }
+    }
+  },
+  "attributes": {
+    "SUPREMACY": true
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group3/set_1087/blazing_brawls/spell_ascendancy.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/blazing_brawls/spell_ascendancy.json
@@ -1,29 +1,15 @@
 {
   "name": "Ascendancy",
-  "baseManaCost": 5,
+  "baseManaCost": 6,
   "type": "SPELL",
   "heroClass": "RUST",
   "rarity": "RARE",
-  "description": "Summon a 4/4 Dragon, or two if you already control a Dragon.",
+  "description": "Summon two 4/4 Dragons.",
   "targetSelection": "NONE",
   "spell": {
-    "class": "EitherOrSpell",
-    "condition": {
-      "class": "MinionOnBoardCondition",
-      "cardFilter": {
-        "class": "RaceFilter",
-        "race": "DRAGON"
-      }
-    },
-    "spell1": {
-      "class": "SummonSpell",
-      "value": 2,
-      "card": "token_44dragon"
-    },
-    "spell2": {
-      "class": "SummonSpell",
-      "card": "token_44dragon"
-    }
+    "class": "SummonSpell",
+    "value": 2,
+    "card": "token_44dragon"
   },
   "attributes": {},
   "collectible": true,

--- a/cards/src/main/resources/cards/custom/group3/set_1087/core/minion_erudite_drakonid.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/core/minion_erudite_drakonid.json
@@ -7,7 +7,7 @@
   "baseHp": 5,
   "rarity": "RARE",
   "race": "DRAGON",
-  "description": "Supremacy: Draw a spell from your deck.",
+  "description": "Supremacy: Draw a spell.",
   "trigger": {
     "eventTrigger": {
       "class": "SupremacyTrigger"

--- a/cards/src/main/resources/cards/custom/group3/set_1087/core/minion_erudite_drakonid.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/core/minion_erudite_drakonid.json
@@ -7,7 +7,7 @@
   "baseHp": 5,
   "rarity": "RARE",
   "race": "DRAGON",
-  "description": "Supremacy: Draw a spell.",
+  "description": "Supremacy: Draw a spell from your deck.",
   "trigger": {
     "eventTrigger": {
       "class": "SupremacyTrigger"

--- a/cards/src/main/resources/cards/custom/group3/set_1087/core/spell_dragonhorn.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/core/spell_dragonhorn.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "RUST",
   "rarity": "COMMON",
-  "description": "Draw 2 Dragons from your deck.",
+  "description": "Draw 2 Dragons.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/core/spell_dragonhorn.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/core/spell_dragonhorn.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "RUST",
   "rarity": "COMMON",
-  "description": "Draw 2 Dragons.",
+  "description": "Draw 2 Dragons from your deck.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/heroic_descent/minion_tian_lon_incorruptible.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/heroic_descent/minion_tian_lon_incorruptible.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tian Lon, Incorruptible",
+  "name": "Izanagi, Incorruptible",
   "baseManaCost": 8,
   "type": "MINION",
   "heroClass": "RUST",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/natures_paths/spell_beast_hunting.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/natures_paths/spell_beast_hunting.json
@@ -27,7 +27,7 @@
   "attributes": {
     "SUPREMACY": true
   },
-  "collectible": true,
+  "collectible": false,
   "set": "CUSTOM",
   "fileFormatVersion": 1
 }

--- a/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/minion_spirit_of_the_serpent.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/minion_spirit_of_the_serpent.json
@@ -6,7 +6,7 @@
   "baseAttack": 0,
   "baseHp": 3,
   "rarity": "RARE",
-  "description": "Hidden for 1 turn. After an enemy minion dies, draw a minion.",
+  "description": "Hidden for 1 turn. After an enemy minion dies, draw a minion from your deck.",
   "trigger": {
     "eventTrigger": {
       "class": "MinionDeathTrigger",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/minion_spirit_of_the_serpent.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/minion_spirit_of_the_serpent.json
@@ -6,7 +6,7 @@
   "baseAttack": 0,
   "baseHp": 3,
   "rarity": "RARE",
-  "description": "Hidden for 1 turn. After an enemy minion dies, draw a minion from your deck.",
+  "description": "Hidden for 1 turn. After an enemy minion dies, draw a minion.",
   "trigger": {
     "eventTrigger": {
       "class": "MinionDeathTrigger",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/spell_draconic_insight.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/spell_draconic_insight.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "RUST",
   "rarity": "EPIC",
-  "description": "This turn, each time you play a card, draw a spell from your deck.",
+  "description": "This turn, each time you play a card, draw a spell.",
   "targetSelection": "NONE",
   "spell": {
     "class": "AddEnchantmentSpell",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/spell_draconic_insight.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/shadow_tremors/spell_draconic_insight.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "RUST",
   "rarity": "EPIC",
-  "description": "This turn, each time you play a card, draw a spell.",
+  "description": "This turn, each time you play a card, draw a spell from your deck.",
   "targetSelection": "NONE",
   "spell": {
     "class": "AddEnchantmentSpell",

--- a/cards/src/main/resources/cards/custom/group3/set_1087/tangled_schemes/minion_thitazov.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/tangled_schemes/minion_thitazov.json
@@ -1,32 +1,34 @@
 {
   "name": "Thitazov",
-  "baseManaCost": 5,
+  "baseManaCost": 6,
   "type": "MINION",
   "heroClass": "RUST",
   "baseAttack": 4,
   "baseHp": 4,
   "rarity": "LEGENDARY",
   "race": "DRAGON",
-  "description": "After your minions destroy a minion, give your other minions +1/+1.",
+  "description": "At the end of your turn, give your other minions +1/+1 and restore them to full Health.",
   "trigger": {
     "eventTrigger": {
-      "class": "AfterPhysicalAttackTrigger",
-      "fireCondition": {
-        "class": "IsDeadCondition"
-      },
-      "sourceEntityType": "MINION",
-      "sourcePlayer": "SELF",
-      "targetEntityType": "MINION"
+      "class": "TurnEndTrigger",
+      "targetPlayer": "SELF"
     },
     "spell": {
-      "class": "BuffSpell",
-      "target": "OTHER_FRIENDLY_MINIONS",
-      "filter": {
-        "class": "IsDestroyedFilter",
-        "invert": true
-      },
-      "attackBonus": 1,
-      "hpBonus": 1
+	  "class": "MetaSpell",
+	  "target": "OTHER_FRIENDLY_MINIONS",
+	  "spells": [
+		{
+          "class": "BuffSpell",
+          "value": 1
+		},
+		{
+		  "class": "HealSpell",
+          "value": {
+            "class": "AttributeValueProvider",
+            "attribute": "MAX_HP"
+          }
+		}
+	  ]
     }
   },
   "attributes": {},

--- a/cards/src/main/resources/cards/custom/group4/chef/minion_guerrilla_bouncer.json
+++ b/cards/src/main/resources/cards/custom/group4/chef/minion_guerrilla_bouncer.json
@@ -7,7 +7,7 @@
   "baseHp": 2,
   "rarity": "COMMON",
   "race": "BEAST",
-  "description": "Opener: Draw a 1-Cost card from your deck.",
+  "description": "Opener: Draw a 1-Cost card.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group4/chef/spell_blood_thirst.json
+++ b/cards/src/main/resources/cards/custom/group4/chef/spell_blood_thirst.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "TOAST",
   "rarity": "RARE",
-  "description": "Give a minion +2/+2 and Lifesteal. At the end of its owner's turn, it attacks an adjacent minion.",
+  "description": "Give a minion +2/+2 and Lifedrain. At the end of its owner's turn, it attacks an adjacent minion.",
   "targetSelection": "MINIONS",
   "spell": {
     "class": "MetaSpell",

--- a/cards/src/main/resources/cards/custom/group4/chef/spell_haute_cuisine.json
+++ b/cards/src/main/resources/cards/custom/group4/chef/spell_haute_cuisine.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "TOAST",
   "rarity": "EPIC",
-  "description": "Draw the highest-Cost card from your deck.",
+  "description": "Draw your highest-Cost card.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group6/jdude/minion_holy_giant.json
+++ b/cards/src/main/resources/cards/custom/group6/jdude/minion_holy_giant.json
@@ -7,7 +7,7 @@
   "baseHp": 10,
   "rarity": "EPIC",
   "race": "ELEMENTAL",
-  "description": "Lifesteal. Costs (1) less each time a friendly character was healed this game.",
+  "description": "Lifedrain. Costs (1) less each time a friendly character was healed this game.",
   "attributes": {
     "LIFESTEAL": true
   },

--- a/cards/src/main/resources/cards/custom/group6/witch_doctor/minion_dreadweaver.json
+++ b/cards/src/main/resources/cards/custom/group6/witch_doctor/minion_dreadweaver.json
@@ -7,7 +7,7 @@
   "baseHp": 6,
   "rarity": "RARE",
   "race": "BEAST",
-  "description": "Opener: Choose a minion. Draw 2 minions of the same Cost from your deck.",
+  "description": "Opener: Choose a minion. Draw 2 minions of the same Cost.",
   "battlecry": {
     "targetSelection": "MINIONS",
     "spell": {

--- a/cards/src/main/resources/cards/custom/group6/witch_doctor/minion_forgotten_ancestor.json
+++ b/cards/src/main/resources/cards/custom/group6/witch_doctor/minion_forgotten_ancestor.json
@@ -6,7 +6,7 @@
   "baseAttack": 2,
   "baseHp": 3,
   "rarity": "RARE",
-  "description": "Aftermath: Give a random friendly minion Guard and Lifesteal.",
+  "description": "Aftermath: Give a random friendly minion Guard and Lifedrain.",
   "deathrattle": {
     "class": "MetaSpell",
     "target": "FRIENDLY_MINIONS",

--- a/cards/src/main/resources/cards/custom/group6/witch_doctor/spell_corvid_call.json
+++ b/cards/src/main/resources/cards/custom/group6/witch_doctor/spell_corvid_call.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "ROSE",
   "rarity": "COMMON",
-  "description": "Add a random Beast to your hand. Draw a Beast from your deck.",
+  "description": "Add a random Beast to your hand. Draw a Beast.",
   "targetSelection": "NONE",
   "spell": {
     "class": "MetaSpell",

--- a/cards/src/main/resources/cards/custom/group6/witch_doctor/spell_morbid_mockery.json
+++ b/cards/src/main/resources/cards/custom/group6/witch_doctor/spell_morbid_mockery.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "ROSE",
   "rarity": "COMMON",
-  "description": "Draw an Aftermath minion from your deck. Give it Guard.",
+  "description": "Draw an Aftermath minion. Give it Guard.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/group8/minion_clumsy_dryad.json
+++ b/cards/src/main/resources/cards/custom/group8/minion_clumsy_dryad.json
@@ -6,7 +6,7 @@
   "baseAttack": 4,
   "baseHp": 5,
   "rarity": "COMMON",
-  "description": "Lifesteal. Aftermath: Restore #2 Health to ALL characters.",
+  "description": "Lifedrain. Aftermath: Restore #2 Health to ALL characters.",
   "deathrattle": {
     "class": "HealSpell",
     "target": "ALL_CHARACTERS",

--- a/cards/src/main/resources/cards/custom/group8/neutral/minion_eyeweaver.json
+++ b/cards/src/main/resources/cards/custom/group8/neutral/minion_eyeweaver.json
@@ -7,7 +7,7 @@
   "baseHp": 7,
   "rarity": "COMMON",
   "race": "BEAST",
-  "description": "Lifesteal, Toxic.",
+  "description": "Lifedrain. Toxic.",
   "attributes": {
     "LIFESTEAL": true,
     "POISONOUS": true

--- a/cards/src/main/resources/cards/custom/group8/neutral/minion_fel_manticore.json
+++ b/cards/src/main/resources/cards/custom/group8/neutral/minion_fel_manticore.json
@@ -7,7 +7,7 @@
   "baseHp": 12,
   "rarity": "COMMON",
   "race": "DEMON",
-  "description": "Guard. Lifesteal.",
+  "description": "Guard. Lifedrain.",
   "attributes": {
     "LIFESTEAL": true,
     "TAUNT": true

--- a/cards/src/main/resources/cards/custom/group8/neutral/minion_treeleach.json
+++ b/cards/src/main/resources/cards/custom/group8/neutral/minion_treeleach.json
@@ -6,7 +6,7 @@
   "baseAttack": 1,
   "baseHp": 1,
   "rarity": "COMMON",
-  "description": "Lifesteal. Aftermath: Deal 1 damage to all minions.",
+  "description": "Lifedrain. Aftermath: Deal 1 damage to all minions.",
   "deathrattle": {
     "class": "DamageSpell",
     "target": "ALL_MINIONS",

--- a/cards/src/main/resources/cards/custom/group8/occultist/classic/spell_ancient_readings.json
+++ b/cards/src/main/resources/cards/custom/group8/occultist/classic/spell_ancient_readings.json
@@ -4,7 +4,7 @@
   "type": "SPELL",
   "heroClass": "DARKGREEN",
   "rarity": "RARE",
-  "description": "Draw the highest-Cost card from your deck.",
+  "description": "Draw your highest-Cost card.",
   "targetSelection": "NONE",
   "spell": {
     "class": "FromDeckToHandSpell",

--- a/cards/src/main/resources/cards/custom/ringmaster/expac1/minion_handsome_handler.json
+++ b/cards/src/main/resources/cards/custom/ringmaster/expac1/minion_handsome_handler.json
@@ -6,7 +6,7 @@
   "baseAttack": 5,
   "baseHp": 4,
   "rarity": "EPIC",
-  "description": "Opener: For each friendly minion, draw your Signature from your deck.",
+  "description": "Opener: For each friendly minion, draw a copy of your Signature.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {


### PR DESCRIPTION
Tweaked cards' wordings for the following:

- Removing "from your deck" from card-drawing effects.

- Changing Lifedrain cards to not still say Lifesteal.

Also tweaked a couple of old, outdated Dragoon cards to be in line with what they should be.