### PR TITLE
Fix #1614

### DIFF
--- a/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 1/minion_lords_guard.json
+++ b/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 1/minion_lords_guard.json
@@ -19,7 +19,7 @@
           "class": "SpecificCardFilter",
           "cards": [
             "token_captive_overlord",
-            "token_captiveGuard_overlord",
+            "token_captiveguard_overlord",
             "token_underling_overlord"
           ]
         },

--- a/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/minion_sinister_jailer.json
+++ b/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/minion_sinister_jailer.json
@@ -10,8 +10,8 @@
   "deathrattle": {
     "class": "SummonSpell",
     "cards": [
-      "token_captiveGuard_overlord",
-      "token_captiveGuard_overlord"
+      "token_captiveguard_overlord",
+      "token_captiveguard_overlord"
     ]
   },
   "attributes": {

--- a/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/pact_reinforcements.json
+++ b/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/pact_reinforcements.json
@@ -24,8 +24,8 @@
       "spell": {
         "class": "SummonSpell",
         "cards": [
-          "token_captiveGuard_overlord",
-          "token_captiveGuard_overlord"
+          "token_captiveguard_overlord",
+          "token_captiveguard_overlord"
         ]
       }
     }

--- a/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/spell_destroy_the_strong.json
+++ b/cards/src/main/resources/cards/custom/group4/Overlord/Custom Set 2/spell_destroy_the_strong.json
@@ -14,7 +14,8 @@
       "class": "SpecificCardFilter",
       "cards": [
         "token_captive_overlord",
-        "token_captiveGuard_overlord"
+        "token_captiveguard_overlord",
+        "token_underling_overlord"
       ],
       "invert": true
     }

--- a/cards/src/test/java/com/hiddenswitch/spellsource/tests/cards/OverlordTests.java
+++ b/cards/src/test/java/com/hiddenswitch/spellsource/tests/cards/OverlordTests.java
@@ -30,4 +30,17 @@ public class OverlordTests extends TestBase {
 			assertEquals(player.getHero().getHp(), player.getHero().getBaseHp() - 2);
 		}, HeroClass.CRIMSON, HeroClass.CRIMSON);
 	}
+
+	@Test
+	public void testDestroyTheStrong() {
+		runGym((context, player, opponent) -> {
+			Minion captive = playMinionCard(context, player, "token_captiveguard_overlord");
+			playCard(context, player, "spell_destroy_the_strong");
+			assertFalse(captive.isDestroyed());
+			destroy(context, captive);
+			assertEquals(1, player.getMinions().size());
+			playCard(context, player, "spell_destroy_the_strong");
+			assertEquals(1, player.getMinions().size());
+		});
+	}
 }

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -4,6 +4,9 @@ date: "2020-02-01"
 path: "/whats-new"
 header: true
 ---
+### Upcoming Changes
+ - Overlord's Destroy the Strong now properly doesn't damage Underlings, and multiple cards should now better recognize Captives with Guard. (1614)
+
 
 ### 0.8.71-3.1.1 (March 28, 2020)
 


### PR DESCRIPTION
" - Overlord's Destroy the Strong now properly doesn't damage Underlings, and multiple cards should now better recognize Captives with Guard. (1614)"
