### PR TITLE
Fix #1634

### DIFF
--- a/cards/src/main/resources/cards/custom/Exile/Verdant Dreams/minion_obsigon_bounty_sorcerer.json
+++ b/cards/src/main/resources/cards/custom/Exile/Verdant Dreams/minion_obsigon_bounty_sorcerer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Obsigon, Bounty Sorcerer",
+  "name": "Battlemage Zhou",
   "baseManaCost": 6,
   "type": "MINION",
   "heroClass": "CAMO",

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -6,7 +6,7 @@ header: true
 ---
 
 ### Upcoming Changes
- - Obsigon, Bounty Sorcerer has been renamed to Battlemage Zhou
+ - Obsigon, Bounty Sorcerer has been renamed to Battlemage Zhou (1634)
 
 ### 0.8.71-3.1.1 (March 28, 2020)
 

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -5,6 +5,9 @@ path: "/whats-new"
 header: true
 ---
 
+### Upcoming Changes
+ - Obsigon, Bounty Sorcerer has been renamed to Battlemage Zhou
+
 ### 0.8.71-3.1.1 (March 28, 2020)
 
  - Both versions of Doodles now work. (1632)


### PR DESCRIPTION
 - Obsigon, Bounty Sorcerer has been renamed to Battlemage Zhou (1634)