### PR TITLE
Fix #1638

### DIFF
--- a/cards/src/main/resources/cards/custom/Oni-Queen/Lun Fun Set/minion_draconic_doubler.json
+++ b/cards/src/main/resources/cards/custom/Oni-Queen/Lun Fun Set/minion_draconic_doubler.json
@@ -2,7 +2,7 @@
   "name": "Draconic Doubler",
   "baseManaCost": 8,
   "type": "MINION",
-  "heroClass": "ANY",
+  "heroClass": "BLUEGREY",
   "baseAttack": 3,
   "baseHp": 7,
   "rarity": "COMMON",

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -5,6 +5,9 @@ path: "/whats-new"
 header: true
 ---
 
+### Upcoming Changes
+ - Draconic Doubler is now correctly an Oni-Queen card.
+
 ### 0.8.71-3.1.1 (March 28, 2020)
 
  - Both versions of Doodles now work. (1632)

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -6,7 +6,7 @@ header: true
 ---
 
 ### Upcoming Changes
- - Draconic Doubler is now correctly an Oni-Queen card.
+ - Draconic Doubler is now correctly an Oni-Queen card. (1638)
 
 ### 0.8.71-3.1.1 (March 28, 2020)
 


### PR DESCRIPTION
 - Draconic Doubler is now correctly an Oni-Queen card. (1638)