### PR TITLE
Fix #1657

### DIFF
--- a/cards/src/test/java/com/hiddenswitch/spellsource/tests/cards/VampireLordTests.java
+++ b/cards/src/test/java/com/hiddenswitch/spellsource/tests/cards/VampireLordTests.java
@@ -1,5 +1,6 @@
 package com.hiddenswitch.spellsource.tests.cards;
 
+import net.demilich.metastone.game.actions.DiscoverAction;
 import net.demilich.metastone.game.cards.Attribute;
 import net.demilich.metastone.game.cards.Card;
 import net.demilich.metastone.game.cards.CardCatalogue;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -593,6 +596,29 @@ public class VampireLordTests extends TestBase {
 			playCard(context, player, "spell_dream_of_death");
 
 			assertEquals(player.getHero().getHp(), 11);
+		});
+	}
+
+	@Test
+	public void testSpiritSaber() {
+		runGym((context, player, opponent) -> {
+			for (int i = 0; i < 30; i++) {
+				shuffleToDeck(context, player, "spell_lunstone");
+			}
+			Minion testD = playMinionCard(context, player, "minion_test_deathrattle");
+			playCard(context, player, "spell_hate_spike", testD);
+			playCard(context, player, "spell_hex_behemoth", testD);
+			AtomicBoolean b = new AtomicBoolean(false);
+			overrideDiscover(context, player, discoverActions -> {
+				assertEquals(1, discoverActions.size());
+				assertEquals("minion_test_deathrattle", discoverActions.get(0).getCard().getCardId());
+				b.set(true);
+				return discoverActions.get(0);
+			});
+			playCard(context, player, "weapon_spirit_saber");
+			if (!b.get()) {
+				fail();
+			}
 		});
 	}
 }

--- a/game/src/main/java/net/demilich/metastone/game/environment/EnvironmentAftermathTriggeredList.java
+++ b/game/src/main/java/net/demilich/metastone/game/environment/EnvironmentAftermathTriggeredList.java
@@ -23,11 +23,13 @@ public final class EnvironmentAftermathTriggeredList implements EnvironmentValue
 		private SpellDesc spell;
 		private int playerId;
 		private EntityReference source;
+		private String cardId;
 
-		public EnvironmentAftermathTriggeredItem(int playerId, EntityReference source, SpellDesc spell) {
+		public EnvironmentAftermathTriggeredItem(int playerId, EntityReference source, SpellDesc spell, String cardId) {
 			this.spell = spell;
 			this.playerId = playerId;
 			this.source = source;
+			this.cardId = cardId;
 		}
 
 		/**
@@ -42,6 +44,14 @@ public final class EnvironmentAftermathTriggeredList implements EnvironmentValue
 		public EnvironmentAftermathTriggeredItem setSpell(SpellDesc spell) {
 			this.spell = spell;
 			return this;
+		}
+
+		/**
+		 * The exact card id of the source at the time the aftermath was triggered
+		 * @return
+		 */
+		public String getCardId() {
+			return cardId;
 		}
 
 		/**
@@ -97,8 +107,8 @@ public final class EnvironmentAftermathTriggeredList implements EnvironmentValue
 	 * @param source
 	 * @param spell
 	 */
-	public void addAftermath(int playerId, EntityReference source, SpellDesc spell) {
-		aftermaths.add(new EnvironmentAftermathTriggeredItem(playerId, source, spell));
+	public void addAftermath(int playerId, EntityReference source, SpellDesc spell, String cardId) {
+		aftermaths.add(new EnvironmentAftermathTriggeredItem(playerId, source, spell, cardId));
 	}
 
 	/**

--- a/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -4079,9 +4079,12 @@ public class GameLogic implements Cloneable, Serializable, IdFactory {
 			if (doubleDeathrattles) {
 				// TODO: Likewise, with double deathrattles, make sure that we can still target whatever we're targeting in the spells (possibly metaspells!)
 				castSpell(playerId, deathrattle, sourceReference, EntityReference.NONE, TargetSelection.NONE, true, null);
+				if (shouldAddToDeathrattlesTriggered) {
+					context.getAftermaths().addAftermath(playerId, sourceReference, deathrattle, context.resolveSingleTarget(sourceReference).getSourceCard().getCardId());
+				}
 			}
 			if (shouldAddToDeathrattlesTriggered) {
-				context.getAftermaths().addAftermath(playerId, sourceReference, deathrattle);
+				context.getAftermaths().addAftermath(playerId, sourceReference, deathrattle, context.resolveSingleTarget(sourceReference).getSourceCard().getCardId());
 			}
 		}
 	}

--- a/game/src/main/java/net/demilich/metastone/game/spells/TriggerDeathrattleSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/TriggerDeathrattleSpell.java
@@ -45,11 +45,11 @@ public class TriggerDeathrattleSpell extends Spell {
 			Card card = (Card) target;
 			if (card.getDesc().getDeathrattle() != null) {
 				SpellUtils.castChildSpell(context, player, card.getDesc().getDeathrattle(), source, target);
-				context.getAftermaths().addAftermath(player.getId(), source.getReference(), card.getDesc().getDeathrattle());
+				context.getAftermaths().addAftermath(player.getId(), source.getReference(), card.getDesc().getDeathrattle(), source.getSourceCard().getCardId());
 			}
 			for (SpellDesc deathrattle : new ArrayList<>(card.getDeathrattleEnchantments())) {
 				SpellUtils.castChildSpell(context, player, deathrattle, source, target);
-				context.getAftermaths().addAftermath(player.getId(), source.getReference(), deathrattle);
+				context.getAftermaths().addAftermath(player.getId(), source.getReference(), deathrattle, source.getSourceCard().getCardId());
 			}
 
 			if (card.getDesc().getDeathrattle() == null && card.getDeathrattleEnchantments().isEmpty()) {

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/source/AftermathsCardSource.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/source/AftermathsCardSource.java
@@ -20,13 +20,20 @@ public class AftermathsCardSource extends CardSource {
 
 	@Override
 	protected CardList match(GameContext context, Entity source, Player player) {
-		return context.getAftermaths().getAftermaths()
+		/*context.getAftermaths().getAftermaths()
 				.stream()
 				.filter(aftermath -> aftermath.getPlayerId() == player.getId())
 				.map(aftermath -> context.resolveSingleTarget(aftermath.getSource(), false))
 				.filter(Objects::nonNull)
 				.map(Entity::getSourceCard)
 				.filter(Objects::nonNull)
+				.collect(Collectors.toCollection(CardArrayList::new));*/
+		return context.getAftermaths().getAftermaths()
+				.stream()
+				.filter(aftermath -> aftermath.getPlayerId() == player.getId())
+				.map(aftermath -> aftermath.getCardId())
+				.filter(Objects::nonNull)
+				.map(context::getCardById)
 				.collect(Collectors.toCollection(CardArrayList::new));
 	}
 }

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/source/AftermathsCardSource.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/source/AftermathsCardSource.java
@@ -5,12 +5,13 @@ import net.demilich.metastone.game.Player;
 import net.demilich.metastone.game.cards.CardArrayList;
 import net.demilich.metastone.game.cards.CardList;
 import net.demilich.metastone.game.entities.Entity;
+import net.demilich.metastone.game.environment.EnvironmentAftermathTriggeredList;
 
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Returns the cards of the aftermaths triggered by the {@link CardSourceArg#TARGET_PLAYER}.
+ * Returns the base cards of the aftermaths triggered by the {@link CardSourceArg#TARGET_PLAYER}.
  */
 public class AftermathsCardSource extends CardSource {
 
@@ -20,18 +21,10 @@ public class AftermathsCardSource extends CardSource {
 
 	@Override
 	protected CardList match(GameContext context, Entity source, Player player) {
-		/*context.getAftermaths().getAftermaths()
-				.stream()
-				.filter(aftermath -> aftermath.getPlayerId() == player.getId())
-				.map(aftermath -> context.resolveSingleTarget(aftermath.getSource(), false))
-				.filter(Objects::nonNull)
-				.map(Entity::getSourceCard)
-				.filter(Objects::nonNull)
-				.collect(Collectors.toCollection(CardArrayList::new));*/
 		return context.getAftermaths().getAftermaths()
 				.stream()
 				.filter(aftermath -> aftermath.getPlayerId() == player.getId())
-				.map(aftermath -> aftermath.getCardId())
+				.map(EnvironmentAftermathTriggeredList.EnvironmentAftermathTriggeredItem::getCardId)
 				.filter(Objects::nonNull)
 				.map(context::getCardById)
 				.collect(Collectors.toCollection(CardArrayList::new));

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -7,6 +7,7 @@ header: true
 
 ### 0.8.72-3.1.1 (In Progress)
 
+ - Spirit Saber now always shows you the exact card that had the aftermath when it triggered, even if it was transformed later. (1657)
  - Archaeologist's Taletellers now correctly looks for minions played this turn, not minions that were played and killed this turn. (1652)
  - The Monk class has been retired. Its class and cards have been made uncollectible by default. "So long and thanks for all deflect." (1635, 1636)
  - Storyteller's Overflowing Energy now correctly only targets one instance of the lowest-cost card in your hand. (1642)
@@ -97,7 +98,6 @@ Exile has been renamed to Rebel.
  - Mysterious Questgiver now properly makes 3 Discoveries. (1579)
  - Nilfheim Needlegunner no longer triggers off of itself. (1610)
  - Herald of Fate no longer just gives you double openers forever. (1577)
- - Spirit Saber now always shows you the exact card that had the aftermath when it triggered, even if it was transformed later. (1657)
 
 ### 0.8.70-3.1.1 (March 27, 2020)
 

--- a/www/src/pages-markdown/whatsnew.md
+++ b/www/src/pages-markdown/whatsnew.md
@@ -97,6 +97,7 @@ Exile has been renamed to Rebel.
  - Mysterious Questgiver now properly makes 3 Discoveries. (1579)
  - Nilfheim Needlegunner no longer triggers off of itself. (1610)
  - Herald of Fate no longer just gives you double openers forever. (1577)
+ - Spirit Saber now always shows you the exact card that had the aftermath when it triggered, even if it was transformed later. (1657)
 
 ### 0.8.70-3.1.1 (March 27, 2020)
 


### PR DESCRIPTION
 - Spirit Saber now always shows you the exact card that had the aftermath when it triggered, even if it was transformed later. (1657)